### PR TITLE
Fails to build with ExtUtils::ParseXS 3.61

### DIFF
--- a/Perl.xs
+++ b/Perl.xs
@@ -32,3 +32,5 @@ MODULE = Net::SSH::Perl  PACKAGE = Net::SSH::Perl
 
 INCLUDE: lib/Net/SSH/Perl/Key/Ed25519.xs
 INCLUDE: lib/Net/SSH/Perl/Cipher/ChachaPoly.xs
+
+MODULE = Net::SSH::Perl  PACKAGE = Net::SSH::Perl


### PR DESCRIPTION
The `perlxs.pod` documentation says that only the `MODULE` value from the last declaration is used, and specifies the name of the boot XSUB which is called when the module is loaded. The INCLUDE-d file lib/Net/SSH/Perl/Cipher/ChachaPoly.xs has:
```
MODULE = Crypt::OpenSSH::ChachaPoly PACKAGE = Crypt::OpenSSH::ChachaPoly
```
so this results in the wrong boot XSUB being defined if it is the last `MODULE` declaration parsed in the file.

Different versions of `ExtUtils::ParseXS` parse `INCLUDE` directives in different orders, so append an additional declaration at the end of `Perl.xs` to ensure that the correct one is used.